### PR TITLE
docs: 移除props注释中的<br> & 中英文用空行隔开

### DIFF
--- a/src/count-down.vue
+++ b/src/count-down.vue
@@ -46,13 +46,14 @@ export default {
       default: true
     },
     /**
-     * output format<br>
-     * 输出格式。<br>
-     * default: 'dd 天 hh 时 mm 分 ss 秒'. The actual remain days, hours, minutes & seconds will replace these optional dd, hh, mm & ss specifiers<br>
-     * 默认值：'dd 天 hh 时 mm 分 ss 秒'。剩余时间的日、时、分和秒数据，会替换字符串中的dd、hh、mm和ss标识符，且都是可选的<br>
-     * the default value will change according to whether there are days, hours, minutes & seconds
-     * 默认值会根据是否传入days, hours, minutes, seconds而变化<br>
+     * Output format.
+     * Default: 'dd 天 hh 时 mm 分 ss 秒'. These dd, hh, mm & ss specifiers are optional.
+     * The default value will change according to whether there are days, hours, minutes & seconds,
      * e.g., if user just pass minutes, then the default value will be 'mm 分 ss 秒'
+     *
+     * 输出格式。
+     * 默认值：'dd 天 hh 时 mm 分 ss 秒'。dd、hh、mm和ss标识符都是可选的。
+     * 默认值会根据是否传入days, hours, minutes, seconds而变化，
      * 比如用户只传了minutes，那么默认值就变为'mm 分 ss 秒'
      */
     format: {


### PR DESCRIPTION
## Why
代码注释中的换行在styleguide中无效，所以添加了`<br>`。但在console端`<br>`会被转义且显示出来

## How
1. 移除注释中的`<br>`，中英文通过空行隔开，保持注释的简洁
2. 注释末尾添加逗号句号，尽可能保证styleguidist的可读性，目标是和其他组件文档在styleguidist的可读性一致
3. 在console端可实现正确显示注释中的换行的效果，保证console端的文档可读

## Test
已在console端测试过，通过`注释.replace(/\n/g, '  \n')`在换行符前插入两空格，即可在页面展示换行